### PR TITLE
chore: ignore `/.cpcache`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pom.xml.asc
 *.db
 CHANGELOG.md
 *.iml
+/.cpcache


### PR DESCRIPTION
When I run the command [`clojure -X:test`](https://github.com/TheAlgorithms/Clojure/blob/a43cea59b6306559e5dac7328f9f5f8cf1f4a0bb/README.md?plain=1#L12), a directory `.cpcache/` is created. I think it should be ignored.  [gitignore.io](https://www.toptal.com/developers/gitignore/api/clojure) has similar view on this matter.

This PR adds it to the `.gitignore`.
