### PR TITLE
chore: add `clojure_test.yml`

### DIFF
--- a/.github/workflows/clojure_test.yml
+++ b/.github/workflows/clojure_test.yml
@@ -1,0 +1,41 @@
+---
+name: clojure_test
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  clojure_test:
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        clojure_version:
+          - "1.10.3.1029"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'adopt'
+
+      - name: Setup clojure
+        uses: DeLaGuardo/setup-clojure@12.1
+        with:
+          cli: ${{matrix.clojure_version}}
+
+      - name: Run tests
+        run: |
+          clojure -X:test
+...


### PR DESCRIPTION
This PR adds a basic _ci_ workflow. The created file was checked by [`yamllint`](https://www.yamllint.com/).

The workflow works on [_my end_](https://github.com/vil02/Clojure/actions/runs/6266157826/job/17016514469) (cf vil02/Clojure#1).