### PR TITLE
chore: add `upload_coverage_report.yml`

### DIFF
--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -1,0 +1,40 @@
+---
+name: upload_coverage_report
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  upload_coverage_report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'adopt'
+
+      - name: Setup clojure
+        uses: DeLaGuardo/setup-clojure@12.1
+        with:
+          cli: "1.10.3.1029"
+
+      - name: Run tests
+        run: |
+          clojure -X:coverage
+
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: "target/coverage/codecov.json"
+          fail_ci_if_error: true
+...

--- a/deps.edn
+++ b/deps.edn
@@ -3,4 +3,12 @@
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "48c3c67"}}
-                  :exec-fn cognitect.test-runner.api/test}}}
+                  :exec-fn cognitect.test-runner.api/test}
+           :coverage {:extra-paths ["test"]
+                      :extra-deps {cloverage/cloverage {:mvn/version "1.2.4"}}
+                      :main-opts ["--main" "cloverage.coverage"
+                                  "--test-ns-path" "test"]
+                      :exec-fn cloverage.coverage/run-project
+                      :exec-args {:src-ns-path  ["src"]
+                                  :test-ns-path ["test"]
+                                  :codecov? true}}}}


### PR DESCRIPTION
Similar to TheAlgorithms/Rust#600.

Since TheAlgorithms exist on [codecov](https://app.codecov.io/github/TheAlgorithms), I think it makes sense to establish an integration with this repository. 