### PR TITLE
[DO NOT MERGE before adding the token] chore: update `codecov-action` to `v4`

### DIFF
--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -32,9 +32,18 @@ jobs:
         run: |
           clojure -X:coverage
 
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage to codecov (tokenless)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: codecov/codecov-action@v4
         with:
+          files: "target/coverage/codecov.json"
+          fail_ci_if_error: true
+
+      - name: Upload coverage to codecov (with token)
+        if: "! github.event.pull_request.head.repo.fork "
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: "target/coverage/codecov.json"
           fail_ci_if_error: true
 ...


### PR DESCRIPTION
Same as TheAlgorithms/Rust#670 - it contains the description of the problem.

Before merging, please add the token from https://app.codecov.io/gh/TheAlgorithms/Clojure/settings as `CODECOV_TOKEN` into the repo secrets.